### PR TITLE
Fixed typo in StatusId

### DIFF
--- a/samples/NetworkData.cs
+++ b/samples/NetworkData.cs
@@ -2,7 +2,7 @@
 {
     public class NetworkDataModel
     {
-        public int StausId { get; set; }
+        public int StatusId { get; set; }
         public string? Ssid { get; set; }
         public string? SsidName { get { return string.IsNullOrWhiteSpace(Ssid) ? "Unknown" : Ssid; } }
         public int IpAddress { get; set; }

--- a/samples/ScanListPage.xaml.cs
+++ b/samples/ScanListPage.xaml.cs
@@ -33,7 +33,7 @@ public partial class ScanListPage : ContentPage
 
     private async void ExecuteInfoCommand(NetworkDataModel model)
     {
-        var info = $"StatusId: {model.StausId}, " +
+        var info = $"StatusId: {model.StatusId}, " +
                $"Ssid: {model.SsidName}, " +
                $"IpAddress: {model.IpAddress}, " +
                $"GatewayAddress: {model.GatewayAddress ?? "N/A"}, " +
@@ -59,7 +59,7 @@ public partial class ScanListPage : ContentPage
             {
                 networkDataModel.Add(new NetworkDataModel() 
                 {
-                    StausId = item.StausId,
+                    StatusId = item.StatusId,
                     IpAddress = (int)item.IpAddress, 
                     Bssid = item.Bssid, 
                     Ssid = item.Ssid, 

--- a/src/MAUIWifiManager/NetworkData.cs
+++ b/src/MAUIWifiManager/NetworkData.cs
@@ -3,7 +3,7 @@ namespace Plugin.MauiWifiManager.Abstractions
 {
     public class NetworkData
     {
-        public int StausId { get; set; }
+        public int StatusId { get; set; }
         public string? Ssid { get; set; }
         public int IpAddress { get; set; }
         public string? GatewayAddress { get; set; }

--- a/src/MAUIWifiManager/WifiNetworkService.android.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.android.cs
@@ -127,7 +127,7 @@ namespace Plugin.MauiWifiManager
                 var wifiManager = _context.GetSystemService(Context.WifiService) as WifiManager;
                 if (wifiManager != null && wifiManager.IsWifiEnabled)
                 {
-                    _networkData.StausId = 1;
+                    _networkData.StatusId = 1;
                     _networkData.Ssid = wifiManager.ConnectionInfo?.SSID?.Trim(new char[] { '"', '\"' });
                     _networkData.Bssid = wifiManager.ConnectionInfo?.BSSID;
                     _networkData.SignalStrength = wifiManager.ConnectionInfo?.Rssi;
@@ -165,7 +165,7 @@ namespace Plugin.MauiWifiManager
 
                                 if (wifiInfo != null && wifiInfo.SupplicantState == SupplicantState.Completed)
                                 {
-                                    _networkData.StausId = 1;
+                                    _networkData.StatusId = 1;
                                     _networkData.Ssid = wifiInfo?.SSID?.Trim(new char[] { '"', '\"' });
                                     _networkData.Bssid = wifiInfo?.BSSID;
                                     _networkData.IpAddress = wifiInfo?.IpAddress ?? 0;
@@ -285,7 +285,7 @@ namespace Plugin.MauiWifiManager
                                 {
                                     if (wifiInfo.SupplicantState == SupplicantState.Completed)
                                     {
-                                        _networkData.StausId = 1;
+                                        _networkData.StatusId = 1;
                                         _networkData.Ssid = wifiInfo?.SSID?.Trim(new char[] { '"', '\"' });
                                         _networkData.Bssid = wifiInfo?.BSSID;
                                         _networkData.IpAddress = wifiInfo?.IpAddress ?? 0;
@@ -321,7 +321,7 @@ namespace Plugin.MauiWifiManager
                                     {
                                         if (OperatingSystem.IsAndroidVersionAtLeast(30) && !OperatingSystem.IsAndroidVersionAtLeast(31))
                                         {
-                                            _networkData.StausId = 1;
+                                            _networkData.StatusId = 1;
                                             _networkData.Ssid = wifiManager.ConnectionInfo?.SSID?.Trim(new char[] { '"', '\"' });
                                             _networkData.Bssid = wifiManager.ConnectionInfo?.BSSID;
                                             _networkData.SignalStrength = wifiManager.ConnectionInfo?.Rssi;
@@ -389,7 +389,7 @@ namespace Plugin.MauiWifiManager
                         {
                             if (networkCapabilities.HasCapability(NetCapability.Validated))
                             {
-                                _networkData.StausId = 1;
+                                _networkData.StatusId = 1;
                                 _networkData.Ssid = wifiManager.ConnectionInfo?.SSID?.Trim(new char[] { '"', '\"' });
                                 _networkData.Bssid = wifiManager.ConnectionInfo?.BSSID;
                                 _networkData.SignalStrength = wifiManager.ConnectionInfo?.Rssi;

--- a/src/MAUIWifiManager/WifiNetworkService.apple.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.apple.cs
@@ -72,7 +72,7 @@ namespace Plugin.MauiWifiManager
                     {
                         if (CaptiveNetwork.TryCopyCurrentNetworkInfo(item, out NSDictionary? info) == StatusCode.OK)
                         {
-                            networkData.StausId = 1;
+                            networkData.StatusId = 1;
                             networkData.Ssid = info?[CaptiveNetwork.NetworkInfoKeySSID].ToString();
                             networkData.Bssid = info?[CaptiveNetwork.NetworkInfoKeyBSSID].ToString();
                             networkData.NativeObject = info;

--- a/src/MAUIWifiManager/WifiNetworkService.uwp.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.uwp.cs
@@ -99,7 +99,7 @@ namespace Plugin.MauiWifiManager
         {
             NetworkData data = new NetworkData();
             ConnectionProfile profile = NetworkInformation.GetInternetConnectionProfile();
-            data.StausId = (int)profile.GetNetworkConnectivityLevel();
+            data.StatusId = (int)profile.GetNetworkConnectivityLevel();
             if (profile.IsWlanConnectionProfile)
             {
                 data.Ssid = profile.WlanConnectionProfileDetails.GetConnectedSsid();


### PR DESCRIPTION
- Fixed a typo where `StatusId` was `StausId`.
- Perhaps `StatusId` could be replaced by an actual `enum` indicating the current status?