### PR TITLE
Add support for .NET 9

### DIFF
--- a/samples/DemoApp.csproj
+++ b/samples/DemoApp.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 
@@ -36,6 +36,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+		<DefaultLanguage>en</DefaultLanguage>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/MAUIWifiManager/MauiWifiManager.csproj
+++ b/src/MAUIWifiManager/MauiWifiManager.csproj
@@ -2,8 +2,8 @@
 
 	<PropertyGroup>
 
-		<TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
 		
 		<AssemblyName>MauiWifiManager</AssemblyName>
 		<RootNamespace>MauiWifiManager</RootNamespace>

--- a/src/MAUIWifiManager/MauiWifiManager.csproj
+++ b/src/MAUIWifiManager/MauiWifiManager.csproj
@@ -10,10 +10,10 @@
 		<PackageId>WifiManager.Maui</PackageId>
 
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
-		<AssemblyVersion>3.0.3</AssemblyVersion>
-		<AssemblyFileVersion>3.0.3</AssemblyFileVersion>
-		<Version>3.0.3</Version>
-		<PackageVersion>3.0.3</PackageVersion>
+		<AssemblyVersion>9.0.0</AssemblyVersion>
+		<AssemblyFileVersion>9.0.0</AssemblyFileVersion>
+		<Version>9.0.0</Version>
+		<PackageVersion>9.0.0</PackageVersion>
 		<PackOnBuild>true</PackOnBuild>
 		<NeutralLanguage>en</NeutralLanguage>
 		<DefineConstants>$(DefineConstants);</DefineConstants>


### PR DESCRIPTION
- Added support for .NET 9.
- Updated versioning strategy: package versions will now begin with the target .NET runtime version (e.g., 9.x.x for .NET 9). This makes it easier to identify the supported .NET runtime while continuing to follow semantic versioning within each major version series.