### PR TITLE
Connect to a Wi-Fi network using bssid

### DIFF
--- a/src/MAUIWifiManager/IWifiNetworkService.shared.cs
+++ b/src/MAUIWifiManager/IWifiNetworkService.shared.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using MAUIWifiManager;
 
 namespace MauiWifiManager
 {
@@ -13,7 +14,7 @@ namespace MauiWifiManager
         /// <summary>
         /// Connects to a Wi-Fi network with the specified SSID and password.
         /// </summary>
-        Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password);
+        Task<WifiManagerResponse<NetworkData>> ConnectWifi(string identifier, string password, WifiNetworkIdentifier type = WifiNetworkIdentifier.Ssid);
 
         /// <summary>
         /// Retrieves details of the currently connected Wi-Fi network.

--- a/src/MAUIWifiManager/WifiNetworkIdentifier.cs
+++ b/src/MAUIWifiManager/WifiNetworkIdentifier.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MAUIWifiManager
+{
+    public enum WifiNetworkIdentifier
+    {
+        Ssid,
+        Bssid
+    }
+}

--- a/src/MAUIWifiManager/WifiNetworkService.android.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.android.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
+using MAUIWifiManager;
 using static Android.Provider.Settings;
 using Context = Android.Content.Context;
 
@@ -49,7 +50,7 @@ namespace MauiWifiManager
         /// <summary>
         /// Connect Wi-Fi
         /// </summary>
-        public async Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password)
+        public async Task<WifiManagerResponse<NetworkData>> ConnectWifi(string identifier, string password, WifiNetworkIdentifier type = WifiNetworkIdentifier.Ssid)
         {
             var response = new WifiManagerResponse<NetworkData>();
             var networkData = new NetworkData();
@@ -75,14 +76,21 @@ namespace MauiWifiManager
                         wifiManager.SetWifiEnabled(true); // Enable Wi-Fi if not already enabled
                     }
                     string wifiSsid = wifiManager.ConnectionInfo?.SSID?.ToString() ?? string.Empty;
-                    if (wifiSsid != string.Format("\"{0}\"", ssid))
+                    if (wifiSsid != string.Format("\"{0}\"", identifier))
                     {
                         System.Diagnostics.Debug.WriteLine("Wi-Fi connection initiated successfully.");
                         WifiConfiguration wifiConfig = new WifiConfiguration
                         {
-                            Ssid = string.Format("\"{0}\"", ssid),
                             PreSharedKey = string.Format("\"{0}\"", password)
                         };
+                        if (type == WifiNetworkIdentifier.Bssid)
+                        {
+                            wifiConfig.Bssid = identifier;
+                        }
+                        else
+                        {
+                            wifiConfig.Ssid = string.Format("\"{0}\"", identifier);
+                        }
                         int netId = wifiManager.AddNetwork(wifiConfig);
                         wifiManager.Disconnect();
                         wifiManager.EnableNetwork(netId, true);
@@ -104,12 +112,12 @@ namespace MauiWifiManager
                 else if (OperatingSystem.IsAndroidVersionAtLeast(29) && !OperatingSystem.IsAndroidVersionAtLeast(30))
                 {
                     //Android version is 29(Android 10)
-                    response = await RequestNetwork(wifiManager, ssid, password);
+                    response = await RequestNetwork(wifiManager, identifier, password, type);
                 }
                 else
                 {
                     //Android version is greater than 29(Android 10)
-                    response = await AddWifiSuggestion(wifiManager, ssid, password);
+                    response = await AddWifiSuggestion(wifiManager, identifier, password, type);
                 }
             }
             catch (Exception ex)
@@ -431,7 +439,7 @@ namespace MauiWifiManager
             return Task.FromResult(response);
         }
 
-        private async Task<WifiManagerResponse<NetworkData>> AddWifiSuggestion(WifiManager wifiManager, string ssid, string psk)
+        private async Task<WifiManagerResponse<NetworkData>> AddWifiSuggestion(WifiManager wifiManager, string ssid, string psk, WifiNetworkIdentifier type = WifiNetworkIdentifier.Ssid)
         {
             var response = new WifiManagerResponse<NetworkData>();
             var networkData = new NetworkData();
@@ -441,10 +449,18 @@ namespace MauiWifiManager
                 try
                 {
                     TaskCompletionSource<NetworkData> tcs = new();
+                    var builder = new WifiNetworkSuggestion.Builder();
+                    if (type == WifiNetworkIdentifier.Bssid)
+                    {
+                        builder.SetBssid(Android.Net.MacAddress.FromString(ssid));
+                    }
+                    else
+                    {
+                        builder.SetSsid(ssid);
+                    }
                     var suggestions = new List<IParcelable>
                                     {
-                                       new WifiNetworkSuggestion.Builder()
-                                        .SetSsid(ssid)
+                                       builder
                                         .SetWpa2Passphrase(psk)
                                         .SetIsUserInteractionRequired(true)
                                         .Build()
@@ -604,7 +620,7 @@ namespace MauiWifiManager
             return response;
         }      
 
-        public async Task<WifiManagerResponse<NetworkData>> RequestNetwork(WifiManager wifiManager, string ssid, string password) 
+        public async Task<WifiManagerResponse<NetworkData>> RequestNetwork(WifiManager wifiManager, string ssid, string password, WifiNetworkIdentifier type = WifiNetworkIdentifier.Ssid)
         {
             var response = new WifiManagerResponse<NetworkData>();
             var networkData = new NetworkData();
@@ -631,7 +647,16 @@ namespace MauiWifiManager
                 if (OperatingSystem.IsAndroidVersionAtLeast(29) && !OperatingSystem.IsAndroidVersionAtLeast(30))
                 {
                     // Creating a connection using this API does not provide an internet connection to the app or to the device.
-                    var specifier = new WifiNetworkSpecifier.Builder().SetSsid(ssid).SetWpa2Passphrase(password).Build();
+                    var specifierBuilder = new WifiNetworkSpecifier.Builder();
+                    if (type == WifiNetworkIdentifier.Bssid)
+                    {
+                        specifierBuilder.SetBssid(Android.Net.MacAddress.FromString(ssid));
+                    }
+                    else
+                    {
+                        specifierBuilder.SetSsid(ssid);
+                    }
+                    var specifier = specifierBuilder.SetWpa2Passphrase(password).Build();
                     var request = new NetworkRequest.Builder()?
                         .AddTransportType(TransportType.Wifi)?
                         .SetNetworkSpecifier(specifier)?

--- a/src/MAUIWifiManager/WifiNetworkService.apple.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.apple.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using MAUIWifiManager;
 using SystemConfiguration;
 using UIKit;
 
@@ -30,19 +31,28 @@ namespace MauiWifiManager
         /// <summary>
         /// Connect to Wifi
         /// </summary>
-        /// <param name="ssid"></param>
+        /// <param name="identifier"></param>
         /// <param name="password"></param>
+        /// <param name="type"></param>
         /// <returns></returns>
-        public async Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password)
+        public async Task<WifiManagerResponse<NetworkData>> ConnectWifi(string identifier, string password, WifiNetworkIdentifier type = WifiNetworkIdentifier.Ssid)
         {
            
+            if (type == WifiNetworkIdentifier.Bssid)
+            {
+                Debug.WriteLine("Connecting by BSSID is not supported on iOS.");
+                return WifiManagerResponse<NetworkData>.ErrorResponse(
+                    WifiErrorCodes.UnsupportedHardware,
+                    "Connecting by BSSID is not supported on iOS.");
+            }
+
             try
             {
                 // Remove any existing configuration for the SSID
-                NEHotspotConfigurationManager.SharedManager.RemoveConfiguration(ssid);
+                NEHotspotConfigurationManager.SharedManager.RemoveConfiguration(identifier);
 
                 // Create a new configuration for the SSID and password
-                var config = new NEHotspotConfiguration(ssid, password, isWep: false)
+                var config = new NEHotspotConfiguration(identifier, password, isWep: false)
                 {
                     JoinOnce = false
                 };

--- a/src/MAUIWifiManager/WifiNetworkService.net.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.net.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using MAUIWifiManager;
 using MauiWifiManager.Abstractions;
 
 namespace MauiWifiManager
@@ -14,7 +15,7 @@ namespace MauiWifiManager
     {
         public WifiNetworkService() { }
 
-        public Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password)
+        public Task<WifiManagerResponse<NetworkData>> ConnectWifi(string identifier, string password, WifiNetworkIdentifier type = WifiNetworkIdentifier.Ssid)
         {
             return Task.FromResult(WifiManagerResponse<NetworkData>.ErrorResponse(WifiErrorCodes.NetworkUnavailable, "Platform Wi-Fi implementation is not available in this build."));
         }

--- a/src/MAUIWifiManager/WifiNetworkService.windows.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.windows.cs
@@ -11,6 +11,7 @@ using Windows.Networking;
 using Windows.Networking.Connectivity;
 using Windows.Security.Credentials;
 using Windows.System;
+using MAUIWifiManager;
 
 namespace MauiWifiManager
 {
@@ -26,7 +27,7 @@ namespace MauiWifiManager
         /// <summary>
         /// Connect Wi-Fi
         /// </summary>
-        public async Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password)
+        public async Task<WifiManagerResponse<NetworkData>> ConnectWifi(string identifier, string password, WifiNetworkIdentifier type = WifiNetworkIdentifier.Ssid)
         {
             var response = new WifiManagerResponse<NetworkData>();
             var credential = new PasswordCredential
@@ -59,7 +60,8 @@ namespace MauiWifiManager
                 WiFiAvailableNetwork? wiFiAvailableNetwork = null;
                 foreach (var network in adapter.NetworkReport.AvailableNetworks)
                 {
-                    if (network.Ssid == ssid)
+                    if (type == WifiNetworkIdentifier.Ssid && network.Ssid == identifier ||
+                        type == WifiNetworkIdentifier.Bssid && network.Bssid == identifier)
                     {
                         wiFiAvailableNetwork = network;
                         break;


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Currently, ConnectWifi only supports connecting to a Wi-Fi network by its SSID. In environments where multiple access points share the same SSID (e.g., enterprise networks, mesh setups or spoofing attempts), there is no way to target a specific access point by its BSSID (MAC address).

**Describe the solution you'd like**
Add a WifiNetworkIdentifier enum (Ssid, Bssid) and an optional type parameter to ConnectWifi, defaulting to Ssid for backward compatibility. When Bssid is specified, the platform implementation connects using the BSSID instead of the SSID.
- Windows: Match the scanned network by BSSID before connecting.
- Android: Use SetBssid(MacAddress) on WifiNetworkSpecifier.Builder (API 29) and WifiNetworkSuggestion.Builder (API 30+). For pre-API 29, set WifiConfiguration.Bssid.
- iOS: Return an UnsupportedHardware error, as NEHotspotConfiguration does not support BSSID-based connections.

**Describe alternatives you've considered**
- Adding a separate ConnectWifiBssid method, but this would duplicate most of the connection logic and increase maintenance burden.
- Accepting a BSSID as an optional second parameter alongside SSID, but a BSSID already uniquely identifies a single access point, making the SSID redundant in that case.

**Additional context**
The BSSID for a given SSID can already be discovered using the existing ScanWifiNetworks method, which returns both Ssid and Bssid on Android and Windows.