### PR TITLE
Add bssid on connect method

### DIFF
--- a/samples/ConnectWifi.xaml.cs
+++ b/samples/ConnectWifi.xaml.cs
@@ -17,7 +17,7 @@ public partial class ConnectWifi : ContentPage
             return;
         }
 
-        var response = await CrossWifiManager.Current.ConnectWifi(WifiSsid.Text, WifiPassword.Text);
+        var response = await CrossWifiManager.Current.ConnectWifiAsync(WifiSsid.Text, WifiPassword.Text);
         if (response.ErrorCode == WifiErrorCodes.Success)
             await DisplayAlertAsync("Wi-Fi Info", response?.Data?.Ssid?.ToString(),"OK");
         else

--- a/samples/DisconnectWifi.xaml.cs
+++ b/samples/DisconnectWifi.xaml.cs
@@ -16,10 +16,10 @@ public partial class DisconnectWifi : ContentPage
         PermissionStatus status = await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
         if (status == PermissionStatus.Granted || DeviceInfo.Current.Platform == DevicePlatform.WinUI)
         {
-            var response = await CrossWifiManager.Current.GetNetworkInfo();
+            var response = await CrossWifiManager.Current.GetNetworkInfoAsync();
             if (response.ErrorCode == WifiErrorCodes.Success)
             {
-                ssid = response?.Data?.Ssid;
+                ssid = response?.Data.Ssid;
                 ssidTxt.Text = ssid;
             }
                    

--- a/samples/NetworkInfo.xaml.cs
+++ b/samples/NetworkInfo.xaml.cs
@@ -35,7 +35,7 @@ public partial class NetworkInfo : ContentPage
 
     private async Task LoadAndRenderCurrentNetworkInfo()
     {
-        var response = await CrossWifiManager.Current.GetNetworkInfo();
+        var response = await CrossWifiManager.Current.GetNetworkInfoAsync();
         if (response != null)
         {
             if (response.ErrorCode == WifiErrorCodes.Success)

--- a/samples/ScanAndConnect.xaml.cs
+++ b/samples/ScanAndConnect.xaml.cs
@@ -21,7 +21,7 @@ public partial class ScanAndConnect : ContentPage
             var wifiParts = responseString.Split(':', 2);
             string ssid = wifiParts[0];
             string password = wifiParts.Length > 1 ? wifiParts[1] : string.Empty;
-            var response = await CrossWifiManager.Current.ConnectWifi(ssid, password);
+            var response = await CrossWifiManager.Current.ConnectWifiAsync(ssid, password);
             if (response.ErrorCode == WifiErrorCodes.Success)
             {
                 await DisplayAlertAsync("Wi-Fi Info", response?.Data?.NativeObject?.ToString(), "OK");

--- a/samples/ScanListPage.xaml.cs
+++ b/samples/ScanListPage.xaml.cs
@@ -28,7 +28,7 @@ public partial class ScanListPage : ContentPage
             var response = await DisplayPromptAsync("Connect " + model.SsidName, "Enter password to connect");
             if (!string.IsNullOrWhiteSpace(response) && response.Length >= 8)
             {
-                var status = await CrossWifiManager.Current.ConnectWifi(model.SsidName, response);
+                var status = await CrossWifiManager.Current.ConnectWifiAsync(model.SsidName, response);
             }
         }
     }
@@ -56,7 +56,7 @@ public partial class ScanListPage : ContentPage
             await Task.Delay(1000);
             loading.IsRunning = true;
             scanCollectionView.IsVisible = false;
-            var response = await CrossWifiManager.Current.ScanWifiNetworks();
+            var response = await CrossWifiManager.Current.ScanWifiNetworksAsync();
             if (response.ErrorCode == WifiErrorCodes.Success)
             {
                 networkDataModel = new();

--- a/src/MAUIWifiManager/CrossWifiManager.shared.cs
+++ b/src/MAUIWifiManager/CrossWifiManager.shared.cs
@@ -1,7 +1,6 @@
 ﻿#if ANDROID
 using Microsoft.Maui.LifecycleEvents;
 #endif
-
 namespace MauiWifiManager
 {
     /// <summary>
@@ -55,6 +54,59 @@ namespace MauiWifiManager
         internal static Exception NotImplementedInReferenceAssembly()
         {
             return new NotImplementedException("This functionality is not implemented in the portable version of this assembly.  You should reference the NuGet package from your main application project in order to reference the platform-specific implementation.");
+        }
+
+        [Obsolete("Use ConnectWifiAsync(string ssid, string password) or ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default) instead.")]
+        public static Task<Abstractions.WifiManagerResponse<Abstractions.NetworkData>> ConnectWifi(string ssid, string password, string? bssid = null)
+        {
+            return Current.ConnectWifi(ssid, password, bssid);
+        }
+
+        public static Task<Abstractions.WifiManagerResponse<Abstractions.NetworkData>> ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default)
+        {
+            return Current.ConnectWifiAsync(ssid, password, cancellationToken);
+        }
+
+        public static Task<Abstractions.WifiManagerResponse<Abstractions.NetworkData>> ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default)
+        {
+            return Current.ConnectWifiAsync(ssid, password, bssid, cancellationToken);
+        }
+
+        [Obsolete("Use GetNetworkInfoAsync(CancellationToken cancellationToken = default) instead.")]
+        public static Task<Abstractions.WifiManagerResponse<Abstractions.NetworkData>> GetNetworkInfo()
+        {
+            return Current.GetNetworkInfo();
+        }
+
+        public static Task<Abstractions.WifiManagerResponse<Abstractions.NetworkData>> GetNetworkInfoAsync(CancellationToken cancellationToken = default)
+        {
+            return Current.GetNetworkInfoAsync(cancellationToken);
+        }
+
+        public static void DisconnectWifi(string ssid)
+        {
+            Current.DisconnectWifi(ssid);
+        }
+
+        public static Task<bool> OpenWifiSetting()
+        {
+            return Current.OpenWifiSetting();
+        }
+
+        [Obsolete("Use ScanWifiNetworksAsync(CancellationToken cancellationToken = default) instead.")]
+        public static Task<Abstractions.WifiManagerResponse<List<Abstractions.NetworkData>>> ScanWifiNetworks()
+        {
+            return Current.ScanWifiNetworks();
+        }
+
+        public static Task<Abstractions.WifiManagerResponse<List<Abstractions.NetworkData>>> ScanWifiNetworksAsync(CancellationToken cancellationToken = default)
+        {
+            return Current.ScanWifiNetworksAsync(cancellationToken);
+        }
+
+        public static Task<bool> OpenWirelessSetting()
+        {
+            return Current.OpenWirelessSetting();
         }
 
         /// <summary>

--- a/src/MAUIWifiManager/CrossWifiManager.shared.cs
+++ b/src/MAUIWifiManager/CrossWifiManager.shared.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.Maui.Hosting;
-using System;
-
-#if ANDROID
+﻿#if ANDROID
 using Microsoft.Maui.LifecycleEvents;
 #endif
 

--- a/src/MAUIWifiManager/IWifiNetworkService.shared.cs
+++ b/src/MAUIWifiManager/IWifiNetworkService.shared.cs
@@ -1,7 +1,4 @@
 ﻿using MauiWifiManager.Abstractions;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace MauiWifiManager
 {
@@ -21,12 +18,35 @@ namespace MauiWifiManager
         /// BSSID-targeted connection is supported on Android and Windows.
         /// On Apple platforms, the OS API does not support selecting a BSSID for connect.
         /// </summary>
+        [Obsolete("Use ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default) or ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default) instead.")]
         Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password, string? bssid = null);
+
+        /// <summary>
+        /// Connects to a Wi-Fi network with the specified SSID and password.
+        /// When provided, bssid targets a specific access point for that SSID.
+        /// BSSID-targeted connection is supported on Android and Windows.
+        /// On Apple platforms, the OS API does not support selecting a BSSID for connect.
+        /// </summary>
+        Task<WifiManagerResponse<NetworkData>> ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Connects to a Wi-Fi network with the specified SSID and password.
+        /// When provided, bssid targets a specific access point for that SSID.
+        /// BSSID-targeted connection is supported on Android and Windows.
+        /// On Apple platforms, the OS API does not support selecting a BSSID for connect.
+        /// </summary>
+        Task<WifiManagerResponse<NetworkData>> ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves details of the currently connected Wi-Fi network.
         /// </summary>
+        [Obsolete("Use GetNetworkInfoAsync(CancellationToken cancellationToken = default) instead.")]
         Task<WifiManagerResponse<NetworkData>> GetNetworkInfo();
+
+        /// <summary>
+        /// Retrieves details of the currently connected Wi-Fi network.
+        /// </summary>
+        Task<WifiManagerResponse<NetworkData>> GetNetworkInfoAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Disconnects from the specified Wi-Fi network.
@@ -42,7 +62,13 @@ namespace MauiWifiManager
         /// <summary>
         /// Scans for available Wi-Fi networks (Android and Windows only).
         /// </summary>
+        [Obsolete("Use ScanWifiNetworksAsync(CancellationToken cancellationToken = default) instead.")]
         Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworks();
+
+        /// <summary>
+        /// Scans for available Wi-Fi networks (Android and Windows only).
+        /// </summary>
+        Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworksAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Opens the device's wireless settings.

--- a/src/MAUIWifiManager/NetworkData.cs
+++ b/src/MAUIWifiManager/NetworkData.cs
@@ -65,6 +65,7 @@
         NetworkUnavailable = 5,
         OperationTimeout = 6,
         InvalidCredential = 7,
-        UnknownError = 8
+        UnknownError = 8,
+        OperationCanceled = 9
     }
 }

--- a/src/MAUIWifiManager/WifiNetworkService.android.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.android.cs
@@ -4,12 +4,8 @@ using Android.Net.Wifi;
 using Android.OS;
 using Android.Runtime;
 using MauiWifiManager.Abstractions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.NetworkInformation;
 using System.Runtime.Versioning;
-using System.Threading.Tasks;
 using static Android.Provider.Settings;
 using Context = Android.Content.Context;
 
@@ -64,8 +60,29 @@ namespace MauiWifiManager
         /// <summary>
         /// Connect Wi-Fi
         /// </summary>
-        public async Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password, string? bssid = null)
+        [Obsolete("Use ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default) or ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default) instead.")]
+        public Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password, string? bssid = null)
         {
+            return ConnectWifiAsync(ssid, password, bssid, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Connect Wi-Fi
+        /// </summary>
+        public Task<WifiManagerResponse<NetworkData>> ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default)
+        {
+            return ConnectWifiAsync(ssid, password, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Connect Wi-Fi
+        /// </summary>
+        public async Task<WifiManagerResponse<NetworkData>> ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return CreateCanceledResponse<NetworkData>(nameof(ConnectWifi));
+            }
             var response = new WifiManagerResponse<NetworkData>();
             var networkData = new NetworkData();
 
@@ -123,13 +140,17 @@ namespace MauiWifiManager
                 else if (OperatingSystem.IsAndroidVersionAtLeast(29) && !OperatingSystem.IsAndroidVersionAtLeast(30))
                 {
                     //Android version is 29(Android 10)
-                    response = await RequestNetwork(wifiManager, ssid, password, bssid);
+                    response = await RequestNetwork(wifiManager, ssid, password, bssid, cancellationToken);
                 }
                 else
                 {
                     //Android version is greater than 29(Android 10)
-                    response = await AddWifiSuggestion(wifiManager, ssid, password, bssid);
+                    response = await AddWifiSuggestion(wifiManager, ssid, password, bssid, cancellationToken);
                 }
+            }
+            catch (System.OperationCanceledException)
+            {
+                return CreateCanceledResponse<NetworkData>(nameof(ConnectWifi));
             }
             catch (Exception ex)
             {
@@ -177,8 +198,21 @@ namespace MauiWifiManager
         /// <summary>
         /// Get Wi-Fi Network Info
         /// </summary>
-        public async Task<WifiManagerResponse<NetworkData>> GetNetworkInfo()
+        [Obsolete("Use GetNetworkInfoAsync(CancellationToken cancellationToken = default) instead.")]
+        public Task<WifiManagerResponse<NetworkData>> GetNetworkInfo()
         {
+            return GetNetworkInfoAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Get Wi-Fi Network Info
+        /// </summary>
+        public async Task<WifiManagerResponse<NetworkData>> GetNetworkInfoAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return CreateCanceledResponse<NetworkData>(nameof(GetNetworkInfo));
+            }
             var response = new WifiManagerResponse<NetworkData>();
             var networkData = new NetworkData();
             if (!OperatingSystem.IsAndroidVersionAtLeast(31))
@@ -330,7 +364,14 @@ namespace MauiWifiManager
                     connectivityManager?.RequestNetwork(request, networkCallback);
                     connectivityManager?.RegisterNetworkCallback(request, networkCallback);
 
-                    networkData = await tcs.Task;
+                    try
+                    {
+                        networkData = await tcs.Task.WaitAsync(cancellationToken);
+                    }
+                    catch (System.OperationCanceledException)
+                    {
+                        return CreateCanceledResponse<NetworkData>(nameof(GetNetworkInfo));
+                    }
                     if (networkData != null && networkData.StatusId == 1)
                     {
                         System.Diagnostics.Debug.WriteLine($"Fetched Wi-Fi connection info successfully.");
@@ -390,8 +431,22 @@ namespace MauiWifiManager
         /// <summary>
         /// Scan Wi-Fi Networks
         /// </summary>
+        [Obsolete("Use ScanWifiNetworksAsync(CancellationToken cancellationToken = default) instead.")]
         public Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworks()
         {
+            return ScanWifiNetworksAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Scan Wi-Fi Networks
+        /// </summary>
+        public Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworksAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromResult(CreateCanceledResponse<List<NetworkData>>(nameof(ScanWifiNetworks)));
+            }
+
             var response = new WifiManagerResponse<List<NetworkData>>();
             try
             {
@@ -450,8 +505,12 @@ namespace MauiWifiManager
             return Task.FromResult(response);
         }
 
-        private async Task<WifiManagerResponse<NetworkData>> AddWifiSuggestion(WifiManager wifiManager, string ssid, string psk, string? bssid = null)
+        private async Task<WifiManagerResponse<NetworkData>> AddWifiSuggestion(WifiManager wifiManager, string ssid, string psk, string? bssid = null, CancellationToken cancellationToken = default)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return CreateCanceledResponse<NetworkData>(nameof(AddWifiSuggestion));
+            }
             var response = new WifiManagerResponse<NetworkData>();
             var networkData = new NetworkData();
 
@@ -598,7 +657,8 @@ namespace MauiWifiManager
 
                     // Set a timeout to prevent hanging
                     var timeoutTask = Task.Delay(TimeSpan.FromSeconds(30));
-                    var completedTask = await Task.WhenAny(tcs.Task, timeoutTask);
+                    var networkTask = tcs.Task.WaitAsync(cancellationToken);
+                    var completedTask = await Task.WhenAny(networkTask, timeoutTask);
                     if (completedTask == timeoutTask)
                     {
                         System.Diagnostics.Debug.WriteLine($"Wi-Fi network suggestion Timeout.");
@@ -609,7 +669,7 @@ namespace MauiWifiManager
 
                     // Ensure to unregister the callback when done
                     connectivityManager?.UnregisterNetworkCallback(networkCallback);
-                    networkData = await tcs.Task;
+                    networkData = await networkTask;
 
                     if (networkData != null && networkData.StatusId == (int)WifiErrorCodes.Success)
                     {
@@ -618,6 +678,10 @@ namespace MauiWifiManager
                         response.ErrorMessage = "Wi-Fi network suggestion added successfully.";
                         response.Data = networkData;
                     }
+                }
+                catch (System.OperationCanceledException)
+                {
+                    return CreateCanceledResponse<NetworkData>(nameof(AddWifiSuggestion));
                 }
                 catch (Exception ex)
                 {
@@ -629,8 +693,12 @@ namespace MauiWifiManager
             return response;
         }      
 
-        public async Task<WifiManagerResponse<NetworkData>> RequestNetwork(WifiManager wifiManager, string ssid, string password, string? bssid = null) 
+        public async Task<WifiManagerResponse<NetworkData>> RequestNetwork(WifiManager wifiManager, string ssid, string password, string? bssid = null, CancellationToken cancellationToken = default) 
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return CreateCanceledResponse<NetworkData>(nameof(RequestNetwork));
+            }
             var response = new WifiManagerResponse<NetworkData>();
             var networkData = new NetworkData();
 
@@ -712,7 +780,7 @@ namespace MauiWifiManager
                         _Requested = true;
                     }
                     // Await the task and set response accordingly
-                    networkData = await tcs.Task;
+                    networkData = await tcs.Task.WaitAsync(cancellationToken);
                     if (networkData != null && networkData.StatusId == 1)
                     {
                         System.Diagnostics.Debug.WriteLine($"Wi-Fi connected successfully.");
@@ -727,6 +795,10 @@ namespace MauiWifiManager
                         response.ErrorMessage = "Wi-Fi connection failed.";
                     }
                 }
+            }
+            catch (System.OperationCanceledException)
+            {
+                return CreateCanceledResponse<NetworkData>(nameof(RequestNetwork));
             }
             catch (Exception ex)
             {
@@ -783,6 +855,13 @@ namespace MauiWifiManager
             return bytes is { Length: 4 } ? GetIpAddressFromBytes(bytes) : 0;
         }
 
+        private static WifiManagerResponse<T> CreateCanceledResponse<T>(string operationName)
+        {
+            return WifiManagerResponse<T>.ErrorResponse(
+                WifiErrorCodes.OperationCanceled,
+                $"{operationName} operation was canceled.");
+        }
+
         private void EnsureMonitoringStarted()
         {
             lock (_monitorLock)
@@ -832,7 +911,7 @@ namespace MauiWifiManager
 
             try
             {
-                var info = await GetNetworkInfo();
+                var info = await GetNetworkInfoAsync();
                 if (info.ErrorCode == WifiErrorCodes.Success && info.Data != null)
                 {
                     currentNetwork = CloneNetworkData(info.Data);

--- a/src/MAUIWifiManager/WifiNetworkService.apple.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.apple.cs
@@ -2,14 +2,10 @@
 using Foundation;
 using MauiWifiManager.Abstractions;
 using NetworkExtension;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using System.Threading.Tasks;
 using SystemConfiguration;
 using UIKit;
 
@@ -47,8 +43,32 @@ namespace MauiWifiManager
         /// <param name="ssid"></param>
         /// <param name="password"></param>
         /// <returns></returns>
-        public async Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password, string? bssid = null)
+        [Obsolete("Use ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default) or ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default) instead.")]
+        public Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password, string? bssid = null)
         {
+            return ConnectWifiAsync(ssid, password, bssid, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Connect to Wifi
+        /// </summary>
+        /// <param name="ssid"></param>
+        /// <param name="password"></param>
+        /// <returns></returns>
+        public Task<WifiManagerResponse<NetworkData>> ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default)
+        {
+            return ConnectWifiAsync(ssid, password, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Connect to Wifi
+        /// </summary>
+        /// <param name="ssid"></param>
+        /// <param name="password"></param>
+        /// <returns></returns>
+        public async Task<WifiManagerResponse<NetworkData>> ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
            
             try
             {
@@ -70,20 +90,20 @@ namespace MauiWifiManager
                 });
 
                 // Await the result of the configuration task
-                var error = await tcs.Task;
+                var error = await tcs.Task.WaitAsync(cancellationToken);
 
                 // Handle connection status
                 if (error == null)
                 {
                     // Successfully connected
                     Debug.WriteLine("Successfully connected to the network.");
-                    var networkData = await GetNetworkInfo();
+                    var networkData = await GetNetworkInfoAsync(cancellationToken);
                     return WifiManagerResponse<NetworkData>.SuccessResponse(networkData.Data, $"Successfully connected to the network.");
                 }
                 else if (error.LocalizedDescription == "already associated.")
                 {
                     // Already connected
-                    var networkData = await GetNetworkInfo();
+                    var networkData = await GetNetworkInfoAsync(cancellationToken);
                     return WifiManagerResponse<NetworkData>.SuccessResponse(networkData.Data, $"Already associated with the network.");
                 }
                 else
@@ -154,8 +174,18 @@ namespace MauiWifiManager
         /// <summary>
         /// Get Wi-Fi Network Info
         /// </summary>
-        public async Task<WifiManagerResponse<NetworkData>> GetNetworkInfo()
+        [Obsolete("Use GetNetworkInfoAsync(CancellationToken cancellationToken = default) instead.")]
+        public Task<WifiManagerResponse<NetworkData>> GetNetworkInfo()
         {
+            return GetNetworkInfoAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Get Wi-Fi Network Info
+        /// </summary>
+        public async Task<WifiManagerResponse<NetworkData>> GetNetworkInfoAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             var response = new WifiManagerResponse<NetworkData>();
             var locationManager = new CLLocationManager();
 
@@ -203,7 +233,7 @@ namespace MauiWifiManager
                     response.ErrorMessage = "Location permissions are not granted.";
                     tcs.SetResult(response);
                 }
-                return await tcs.Task;
+                return await tcs.Task.WaitAsync(cancellationToken);
             }           
             else
             {
@@ -262,8 +292,22 @@ namespace MauiWifiManager
         /// <summary>
         /// Scan Wi-Fi Networks
         /// </summary>
+        [Obsolete("Use ScanWifiNetworksAsync(CancellationToken cancellationToken = default) instead.")]
         public Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworks()
         {
+            return ScanWifiNetworksAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Scan Wi-Fi Networks
+        /// </summary>
+        public Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworksAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<WifiManagerResponse<List<NetworkData>>>(cancellationToken);
+            }
+
             var response = new WifiManagerResponse<List<NetworkData>>();
             var wifiNetworks = new List<NetworkData>();
             Debug.WriteLine($"ScanWifiNetworks is not supported on iOS.");
@@ -379,7 +423,7 @@ namespace MauiWifiManager
 
             try
             {
-                var info = await GetNetworkInfo();
+                var info = await GetNetworkInfoAsync();
                 if (info.ErrorCode == WifiErrorCodes.Success && info.Data != null)
                 {
                     currentNetwork = CloneNetworkData(info.Data);

--- a/src/MAUIWifiManager/WifiNetworkService.net.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.net.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using MauiWifiManager.Abstractions;
 
 namespace MauiWifiManager
@@ -16,13 +13,38 @@ namespace MauiWifiManager
 
         public WifiNetworkService() { }
 
+        [Obsolete("Use ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default) or ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default) instead.")]
         public Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password, string? bssid = null)
         {
+            return ConnectWifiAsync(ssid, password, bssid, CancellationToken.None);
+        }
+
+        public Task<WifiManagerResponse<NetworkData>> ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default)
+        {
+            return ConnectWifiAsync(ssid, password, null, cancellationToken);
+        }
+
+        public Task<WifiManagerResponse<NetworkData>> ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<WifiManagerResponse<NetworkData>>(cancellationToken);
+            }
             return Task.FromResult(WifiManagerResponse<NetworkData>.ErrorResponse(WifiErrorCodes.NetworkUnavailable, "Platform Wi-Fi implementation is not available in this build."));
         }
 
+        [Obsolete("Use GetNetworkInfoAsync(CancellationToken cancellationToken = default) instead.")]
         public Task<WifiManagerResponse<NetworkData>> GetNetworkInfo()
         {
+            return GetNetworkInfoAsync(CancellationToken.None);
+        }
+
+        public Task<WifiManagerResponse<NetworkData>> GetNetworkInfoAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<WifiManagerResponse<NetworkData>>(cancellationToken);
+            }
             return Task.FromResult(WifiManagerResponse<NetworkData>.ErrorResponse(WifiErrorCodes.NetworkUnavailable, "Platform Wi-Fi implementation is not available in this build."));
         }
 
@@ -36,8 +58,18 @@ namespace MauiWifiManager
             return Task.FromResult(false);
         }
 
+        [Obsolete("Use ScanWifiNetworksAsync(CancellationToken cancellationToken = default) instead.")]
         public Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworks()
         {
+            return ScanWifiNetworksAsync(CancellationToken.None);
+        }
+
+        public Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworksAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<WifiManagerResponse<List<NetworkData>>>(cancellationToken);
+            }
             return Task.FromResult(WifiManagerResponse<List<NetworkData>>.ErrorResponse(WifiErrorCodes.NetworkUnavailable, "Platform Wi-Fi implementation is not available in this build."));
         }
 

--- a/src/MAUIWifiManager/WifiNetworkService.windows.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.windows.cs
@@ -1,16 +1,10 @@
 ﻿using MauiWifiManager.Abstractions;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
-using System.Threading.Tasks;
 using Windows.Devices.WiFi;
-using Windows.Networking;
 using Windows.Networking.Connectivity;
 using Windows.Security.Credentials;
-using Windows.System;
 
 namespace MauiWifiManager
 {
@@ -41,8 +35,26 @@ namespace MauiWifiManager
         /// <summary>
         /// Connect Wi-Fi
         /// </summary>
-        public async Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password, string? bssid = null)
+        [Obsolete("Use ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default) or ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default) instead.")]
+        public Task<WifiManagerResponse<NetworkData>> ConnectWifi(string ssid, string password, string? bssid = null)
         {
+            return ConnectWifiAsync(ssid, password, bssid, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Connect Wi-Fi
+        /// </summary>
+        public Task<WifiManagerResponse<NetworkData>> ConnectWifiAsync(string ssid, string password, CancellationToken cancellationToken = default)
+        {
+            return ConnectWifiAsync(ssid, password, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Connect Wi-Fi
+        /// </summary>
+        public async Task<WifiManagerResponse<NetworkData>> ConnectWifiAsync(string ssid, string password, string? bssid, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             var response = new WifiManagerResponse<NetworkData>();
             var credential = new PasswordCredential
             {
@@ -70,7 +82,7 @@ namespace MauiWifiManager
             adapter = await WiFiAdapter.FromIdAsync(result[0].Id);
             if (adapter != null)
             {
-                await adapter.ScanAsync();
+                await adapter.ScanAsync().AsTask(cancellationToken);
                 WiFiAvailableNetwork? wiFiAvailableNetwork = null;
                 foreach (var network in adapter.NetworkReport.AvailableNetworks)
                 {
@@ -82,13 +94,13 @@ namespace MauiWifiManager
                 }
                 if (wiFiAvailableNetwork != null)
                 {
-                    var status = await adapter.ConnectAsync(wiFiAvailableNetwork, WiFiReconnectionKind.Automatic, credential);
+                    var status = await adapter.ConnectAsync(wiFiAvailableNetwork, WiFiReconnectionKind.Automatic, credential).AsTask(cancellationToken);
                     if (status.ConnectionStatus == WiFiConnectionStatus.Success)
                     {
                         Debug.WriteLine("Connected successfully to the network.");
                         Windows.Networking.Connectivity.ConnectionProfile InternetConnectionProfile = NetworkInformation.GetInternetConnectionProfile();
                         var hostname = NetworkInformation.GetHostNames().FirstOrDefault(hn => hn.IPInformation?.NetworkAdapter != null && hn.IPInformation.NetworkAdapter.NetworkAdapterId == InternetConnectionProfile?.NetworkAdapter.NetworkAdapterId);
-                        var networkData = await GetNetworkInfo();
+                        var networkData = await GetNetworkInfoAsync(cancellationToken);
                         if (networkData.ErrorCode == WifiErrorCodes.Success)
                         {
                             response.ErrorCode = WifiErrorCodes.Success;
@@ -151,8 +163,22 @@ namespace MauiWifiManager
         /// <summary>
         /// Get Network Info
         /// </summary>
+        [Obsolete("Use GetNetworkInfoAsync(CancellationToken cancellationToken = default) instead.")]
         public Task<WifiManagerResponse<NetworkData>> GetNetworkInfo()
         {
+            return GetNetworkInfoAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Get Network Info
+        /// </summary>
+        public Task<WifiManagerResponse<NetworkData>> GetNetworkInfoAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<WifiManagerResponse<NetworkData>>(cancellationToken);
+            }
+
             var response = new WifiManagerResponse<NetworkData>();
             var networkData = new NetworkData();
 
@@ -234,8 +260,18 @@ namespace MauiWifiManager
         /// <summary>
         /// Scan Wi-Fi Networks
         /// </summary>
-        public async Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworks()
+        [Obsolete("Use ScanWifiNetworksAsync(CancellationToken cancellationToken = default) instead.")]
+        public Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworks()
         {
+            return ScanWifiNetworksAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Scan Wi-Fi Networks
+        /// </summary>
+        public async Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworksAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             var response = new WifiManagerResponse<List<NetworkData>>();
             try
             {
@@ -249,7 +285,7 @@ namespace MauiWifiManager
                     {
                         var wifiAdapter = result[0];
                         Debug.WriteLine($"Wi-Fi Scan started.");
-                        await wifiAdapter.ScanAsync();
+                        await wifiAdapter.ScanAsync().AsTask(cancellationToken);
                         var availableNetworks = wifiAdapter.NetworkReport.AvailableNetworks;
                         foreach (var network in availableNetworks)
                         {
@@ -341,7 +377,7 @@ namespace MauiWifiManager
 
             try
             {
-                var info = await GetNetworkInfo();
+                var info = await GetNetworkInfoAsync();
                 if (info.ErrorCode == WifiErrorCodes.Success && info.Data != null)
                 {
                     currentNetwork = CloneNetworkData(info.Data);


### PR DESCRIPTION
1. Added bssid-aware connect support in the Wi-Fi service APIs and platform implementations.
2. Introduced Async-first API shape with cancellation support.
3. Kept old method names and marked them obsolete for migration compatibility.
4. Added unambiguous overloads for connect with and without bssid.
5. Added dedicated canceled response handling on Android with OperationCanceled error code.
6. Added static convenience wrappers on CrossWifiManager so both patterns work:  CrossWifiManager.Current.MethodAsync(...) &  CrossWifiManager.MethodAsync(...)