### PR TITLE
Add Wi-Fi Device Discovery method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Wi-Fi Manager for .NET MAUI is a simple and powerful library that helps you 
 - **Connect to Wi-Fi**: Connect to Wi-Fi networks using SSID and password.
 - **Get Network Info**: View details about the currently connected network.
 - **Observe Wi-Fi Changes**: Subscribe to connected Wi-Fi changes (including OS-driven changes).
+- **Discover Networks in Real-Time**: Listen to discovered Wi-Fi networks during an active scan session.
 - **Disconnect Wi-Fi**: Disconnect from a specific Wi-Fi network.
 - **Open Wi-Fi Settings**: Provide quick access to device Wi-Fi settings.
 - **Open Wireless Settings**: Provide quick access to device wireless settings.
@@ -114,6 +115,39 @@ var response = await CrossWifiManager.Current.ScanWifiNetworks();
 
 ---
 
+### Discover Networks in Real-Time (Device Discovery)
+
+Use continuous scanning when you want to update your UI as networks are discovered:
+
+```csharp
+using MauiWifiManager;
+using MauiWifiManager.Abstractions;
+
+CrossWifiManager.DeviceDiscovered += (_, network) =>
+{
+    // Called for each discovered SSID/BSSID while scanning is active.
+    System.Diagnostics.Debug.WriteLine($"Discovered: {network.Ssid} ({network.Bssid})");
+};
+
+var startResponse = await CrossWifiManager.StartScanningForDevicesAsync();
+if (startResponse.ErrorCode == WifiErrorCodes.Success && CrossWifiManager.IsScanning)
+{
+    // Scanning is active
+}
+
+// Later, stop scanning
+var stopResponse = await CrossWifiManager.StopScanningAsync();
+```
+
+Notes:
+
+- `DeviceDiscovered` is raised only while scanning is active.
+- `IsScanning` tells whether a scan session is currently running.
+- Continuous discovery is supported on Android and Windows.
+- iOS does not support Wi-Fi network scanning APIs.
+
+---
+
 ### Get Current Network Info
 
 To retrieve details of the currently connected Wi-Fi network:
@@ -201,6 +235,7 @@ public class WifiManagerResponse<T>
 | Get Current Network Info         | ✅      | ✅        | ✅      | Supported on all platforms.            |
 | Disconnect Wi-Fi                 | ✅      | ✅        | ✅      | Supported on all platforms.            |
 | Scan for Available Wi-Fi Networks| ✅      | ❌        | ✅      | Not supported on iOS.                  |
+| Device Discovery (Event-based)   | ✅      | ❌        | ✅      | Use `DeviceDiscovered` with Start/Stop scan methods. |
 | Open Wireless Settings           | ✅      | ✅*       | ✅      | *Opens app settings on iOS.            |
 | Open Wi-Fi Settings              | ✅      | ✅*       | ✅      | *Opens app settings on iOS.            |
 

--- a/samples/ScanListPage.xaml.cs
+++ b/samples/ScanListPage.xaml.cs
@@ -1,26 +1,44 @@
 namespace DemoApp;
 using MauiWifiManager;
 using MauiWifiManager.Abstractions;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 
 public partial class ScanListPage : ContentPage
 {
-    List<NetworkDataModel> networkDataModel = [];
+    private readonly ObservableCollection<NetworkDataModel> _NetworkDataModel = [];
+    private readonly HashSet<string> _DiscoveredNetworkKeys = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Queue<NetworkData> _PendingNetworks = new();
+    private readonly object _QueueLock = new();
+    private bool _IsDeviceDiscoveredSubscribed;
+    private bool _IsProcessingQueue ;
+
     public Command InfoCommand { get; }
     public Command ConnectCommand { get; }
+
     public ScanListPage()
 	{
 		InitializeComponent();
         BindingContext = this;
         InfoCommand = new Command<NetworkDataModel>(ExecuteInfoCommand);
         ConnectCommand = new Command<NetworkDataModel>(ExecuteConnectCommand);
+        scanCollectionView.ItemsSource = _NetworkDataModel;
+        UpdateScanButtonState();
     }
 
     protected override async void OnAppearing()
     {
         base.OnAppearing();
-        await GetWifiList();
+        await StartScanSessionAsync();
     }
+
+    protected override async void OnDisappearing()
+    {
+        await StopScanSessionAsync();
+        UnsubscribeDeviceDiscovered();
+        base.OnDisappearing();
+    }
+
     private async void ExecuteConnectCommand(NetworkDataModel model)
     {
         if (!string.IsNullOrWhiteSpace(model.SsidName))
@@ -43,43 +61,178 @@ public partial class ScanListPage : ContentPage
                $"Bssid: {model.Bssid}";
         await DisplayAlertAsync("Network info", info, "OK");
     }   
+
     private async void ScanClicked(object sender, EventArgs e)
     {
-        await GetWifiList();
-    }
-
-    private async Task GetWifiList()
-    {
-        PermissionStatus status = await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
-        if (status == PermissionStatus.Granted || DeviceInfo.Current.Platform == DevicePlatform.WinUI)
+        if (CrossWifiManager.IsScanning)
         {
-            await Task.Delay(1000);
-            loading.IsRunning = true;
-            scanCollectionView.IsVisible = false;
-            var response = await CrossWifiManager.Current.ScanWifiNetworksAsync();
-            if (response.ErrorCode == WifiErrorCodes.Success)
-            {
-                networkDataModel = new();
-                foreach (var item in response.Data)
-                {
-                    networkDataModel.Add(new NetworkDataModel()
-                    {
-                        StatusId = item.StatusId,
-                        IpAddress = (int)item.IpAddress,
-                        Bssid = item.Bssid,
-                        Ssid = item.Ssid,
-                        GatewayAddress = item.GatewayAddress.ToString(),
-                        NativeObject = item.NativeObject
-                    });
-                }
-                Debug.WriteLine("Networks found: " + networkDataModel.Count);
-                scanCollectionView.ItemsSource = networkDataModel;
-                loading.IsRunning = false;
-                scanCollectionView.IsVisible = true;
-            }
-           
+            await StopScanSessionAsync();
         }
         else
-            await DisplayAlertAsync("No location permisson", "Please provide location permission", "OK");
+        {
+            await StartScanSessionAsync();
+        }
+    }
+
+    private async Task StartScanSessionAsync()
+    {
+        if (!await EnsureLocationPermissionAsync())
+        {
+            return;
+        }
+
+        loading.IsRunning = true;
+        scanCollectionView.IsVisible = true;
+        _NetworkDataModel.Clear();
+        _DiscoveredNetworkKeys.Clear();
+        lock (_QueueLock)
+        {
+            _PendingNetworks.Clear();
+            _IsProcessingQueue = false;
+        }
+
+        SubscribeDeviceDiscovered();
+
+        var response = await CrossWifiManager.StartScanningForDevicesAsync();
+        if (response.ErrorCode == WifiErrorCodes.Success)
+        {
+            UpdateScanButtonState();
+        }
+        else
+        {
+            loading.IsRunning = false;
+            scanCollectionView.IsVisible = true;
+            await DisplayAlertAsync("Scan failed", response.ErrorMessage ?? "Unable to start scanning.", "OK");
+            UpdateScanButtonState();
+        }
+    }
+
+    private async Task StopScanSessionAsync()
+    {
+        var response = await CrossWifiManager.StopScanningAsync();
+        if (response.ErrorCode != WifiErrorCodes.Success)
+        {
+            Debug.WriteLine("Stop scanning failed: " + response.ErrorMessage);
+        }
+
+        lock (_QueueLock)
+        {
+            _PendingNetworks.Clear();
+            _IsProcessingQueue = false;
+        }
+
+        UpdateScanButtonState();
+        loading.IsRunning = false;
+        scanCollectionView.IsVisible = true;
+    }
+
+    private void OnDeviceDiscovered(object? sender, NetworkData network)
+    {
+        lock (_QueueLock)
+        {
+            _PendingNetworks.Enqueue(network);
+            if (_IsProcessingQueue)
+            {
+                return;
+            }
+
+            _IsProcessingQueue = true;
+        }
+
+        _ = ProcessDiscoveredQueueAsync();
+    }
+
+    private async Task ProcessDiscoveredQueueAsync()
+    {
+        while (true)
+        {
+            NetworkData? nextNetwork;
+
+            lock (_QueueLock)
+            {
+                if (_PendingNetworks.Count == 0)
+                {
+                    _IsProcessingQueue = false;
+                    return;
+                }
+
+                nextNetwork = _PendingNetworks.Dequeue();
+            }
+
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                AddDiscoveredNetwork(nextNetwork);
+                loading.IsRunning = false;
+                scanCollectionView.IsVisible = true;
+            });
+
+            await Task.Delay(75);
+        }
+    }
+
+    private void AddDiscoveredNetwork(NetworkData item)
+    {
+        var key = BuildNetworkKey(item.Ssid, item.Bssid);
+        if (!_DiscoveredNetworkKeys.Add(key))
+        {
+            return;
+        }
+
+        _NetworkDataModel.Add(new NetworkDataModel()
+        {
+            StatusId = item.StatusId,
+            IpAddress = item.IpAddress,
+            Bssid = item.Bssid,
+            Ssid = item.Ssid,
+            GatewayAddress = item.GatewayAddress.ToString(),
+            NativeObject = item.NativeObject
+        });
+
+        loading.IsRunning = false;
+        Debug.WriteLine("Networks found: " + _NetworkDataModel.Count);
+    }
+
+    private static string BuildNetworkKey(string? ssid, object? bssid)
+    {
+        return string.Concat(ssid?.Trim() ?? string.Empty, "|", bssid?.ToString()?.Trim() ?? string.Empty);
+    }
+
+    private async Task<bool> EnsureLocationPermissionAsync()
+    {
+        var status = await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
+        if (status == PermissionStatus.Granted || DeviceInfo.Current.Platform == DevicePlatform.WinUI)
+        {
+            return true;
+        }
+
+        await DisplayAlertAsync("No location permisson", "Please provide location permission", "OK");
+        return false;
+    }
+
+    private void SubscribeDeviceDiscovered()
+    {
+        if (_IsDeviceDiscoveredSubscribed)
+        {
+            return;
+        }
+
+        CrossWifiManager.DeviceDiscovered += OnDeviceDiscovered;
+        _IsDeviceDiscoveredSubscribed = true;
+    }
+
+    private void UnsubscribeDeviceDiscovered()
+    {
+        if (!_IsDeviceDiscoveredSubscribed)
+        {
+            return;
+        }
+
+        CrossWifiManager.DeviceDiscovered -= OnDeviceDiscovered;
+        _IsDeviceDiscoveredSubscribed = false;
+    }
+
+    private void UpdateScanButtonState()
+    {
+        scan.Text = CrossWifiManager.IsScanning ? "Stop" : "Scan";
     }
 }

--- a/src/MAUIWifiManager/CrossWifiManager.shared.cs
+++ b/src/MAUIWifiManager/CrossWifiManager.shared.cs
@@ -51,6 +51,26 @@ namespace MauiWifiManager
             }
         }
 
+        /// <summary>
+        /// Raised when a network is discovered during an active scan session.
+        /// </summary>
+        public static event EventHandler<Abstractions.NetworkData>? DeviceDiscovered
+        {
+            add => Current.DeviceDiscovered += value;
+            remove
+            {
+                if (_Implementation != null && _Implementation.IsValueCreated)
+                {
+                    _Implementation.Value.DeviceDiscovered -= value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets whether the current implementation is scanning for devices.
+        /// </summary>
+        public static bool IsScanning => Current.IsScanning;
+
         internal static Exception NotImplementedInReferenceAssembly()
         {
             return new NotImplementedException("This functionality is not implemented in the portable version of this assembly.  You should reference the NuGet package from your main application project in order to reference the platform-specific implementation.");
@@ -102,6 +122,16 @@ namespace MauiWifiManager
         public static Task<Abstractions.WifiManagerResponse<List<Abstractions.NetworkData>>> ScanWifiNetworksAsync(CancellationToken cancellationToken = default)
         {
             return Current.ScanWifiNetworksAsync(cancellationToken);
+        }
+
+        public static Task<Abstractions.WifiManagerResponse<bool>> StartScanningForDevicesAsync(CancellationToken cancellationToken = default)
+        {
+            return Current.StartScanningForDevicesAsync(cancellationToken);
+        }
+
+        public static Task<Abstractions.WifiManagerResponse<bool>> StopScanningAsync(CancellationToken cancellationToken = default)
+        {
+            return Current.StopScanningAsync(cancellationToken);
         }
 
         public static Task<bool> OpenWirelessSetting()

--- a/src/MAUIWifiManager/IWifiNetworkService.shared.cs
+++ b/src/MAUIWifiManager/IWifiNetworkService.shared.cs
@@ -13,6 +13,16 @@ namespace MauiWifiManager
         event EventHandler<WifiNetworkChangedEventArgs>? WifiNetworkChanged;
 
         /// <summary>
+        /// Raised when a Wi-Fi network is discovered while an active scan session is running.
+        /// </summary>
+        event EventHandler<NetworkData>? DeviceDiscovered;
+
+        /// <summary>
+        /// Gets a value indicating whether a scan session is currently running.
+        /// </summary>
+        bool IsScanning { get; }
+
+        /// <summary>
         /// Connects to a Wi-Fi network with the specified SSID and password.
         /// When provided, bssid targets a specific access point for that SSID.
         /// BSSID-targeted connection is supported on Android and Windows.
@@ -69,6 +79,16 @@ namespace MauiWifiManager
         /// Scans for available Wi-Fi networks (Android and Windows only).
         /// </summary>
         Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworksAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Starts a continuous scan session and emits discovered networks through DeviceDiscovered.
+        /// </summary>
+        Task<WifiManagerResponse<bool>> StartScanningForDevicesAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Stops the currently running scan session.
+        /// </summary>
+        Task<WifiManagerResponse<bool>> StopScanningAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Opens the device's wireless settings.

--- a/src/MAUIWifiManager/WifiNetworkService.android.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.android.cs
@@ -21,19 +21,32 @@ namespace MauiWifiManager
         private static ConnectivityManager? _ConnectivityManager;
         private static bool _Requested;
         private static readonly char[] _TrimChars = new char[] { '"', '\"' };
-        private EventHandler<WifiNetworkChangedEventArgs>? _wifiNetworkChanged;
-        private readonly object _monitorLock = new();
-        private NetworkData? _lastKnownNetwork;
-        private bool _isMonitoring;
+        private EventHandler<WifiNetworkChangedEventArgs>? _WifiNetworkChanged;
+        private EventHandler<NetworkData>? _DeviceDiscovered;
+        private readonly object _MonitorLock = new();
+        private readonly object _ScanLock = new();
+        private NetworkData? _LastKnownNetwork;
+        private CancellationTokenSource? _ScanSessionCts;
+        private Task? _ScanSessionTask;
+        private readonly HashSet<string> _DiscoveredNetworkKeys = new(StringComparer.OrdinalIgnoreCase);
+        private bool _IsMonitoring;
+
+        public bool IsScanning { get; private set; }
 
         public event EventHandler<WifiNetworkChangedEventArgs>? WifiNetworkChanged
         {
             add
             {
-                _wifiNetworkChanged += value;
+                _WifiNetworkChanged += value;
                 EnsureMonitoringStarted();
             }
-            remove => _wifiNetworkChanged -= value;
+            remove => _WifiNetworkChanged -= value;
+        }
+
+        public event EventHandler<NetworkData>? DeviceDiscovered
+        {
+            add => _DeviceDiscovered += value;
+            remove => _DeviceDiscovered -= value;
         }
 
         public WifiNetworkService() 
@@ -442,9 +455,14 @@ namespace MauiWifiManager
         /// </summary>
         public Task<WifiManagerResponse<List<NetworkData>>> ScanWifiNetworksAsync(CancellationToken cancellationToken = default)
         {
+            return Task.FromResult(ScanWifiNetworksInternal(cancellationToken));
+        }
+
+        private WifiManagerResponse<List<NetworkData>> ScanWifiNetworksInternal(CancellationToken cancellationToken = default)
+        {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromResult(CreateCanceledResponse<List<NetworkData>>(nameof(ScanWifiNetworks)));
+                return CreateCanceledResponse<List<NetworkData>>(nameof(ScanWifiNetworks));
             }
 
             var response = new WifiManagerResponse<List<NetworkData>>();
@@ -456,7 +474,7 @@ namespace MauiWifiManager
                     System.Diagnostics.Debug.WriteLine($"Wi-Fi Manager is unavailable. Please ensure the device has Wi-Fi capability.");
                     response.ErrorCode = WifiErrorCodes.UnsupportedHardware;
                     response.ErrorMessage = "Wi-Fi Manager is unavailable. Please ensure the device has Wi-Fi capability.";
-                    return Task.FromResult(response);
+                    return response;
                 }
 
                 if (!wifiManager.IsWifiEnabled)
@@ -464,7 +482,7 @@ namespace MauiWifiManager
                     System.Diagnostics.Debug.WriteLine($"Wi-Fi is turned off. Please enable Wi-Fi to proceed.");
                     response.ErrorCode = WifiErrorCodes.WifiNotEnabled;
                     response.ErrorMessage = "Wi-Fi is turned off. Please enable Wi-Fi to proceed.";
-                    return Task.FromResult(response);
+                    return response;
                 }
 
                 List<NetworkData> wifiNetworks = new();
@@ -502,7 +520,71 @@ namespace MauiWifiManager
                 response.ErrorCode = WifiErrorCodes.UnknownError;
                 response.ErrorMessage = $"Error while scanning Wi-Fi: {ex.Message}";
             }
-            return Task.FromResult(response);
+            return response;
+        }
+
+        public Task<WifiManagerResponse<bool>> StartScanningForDevicesAsync(CancellationToken cancellationToken = default)
+        {
+            CheckInit(_Context);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromResult(WifiManagerResponse<bool>.ErrorResponse(WifiErrorCodes.OperationCanceled, "StartScanningForDevicesAsync operation was canceled."));
+            }
+
+            lock (_ScanLock)
+            {
+                if (IsScanning)
+                {
+                    return Task.FromResult(WifiManagerResponse<bool>.SuccessResponse(true, "Scan session is already running."));
+                }
+
+                _DiscoveredNetworkKeys.Clear();
+                _ScanSessionCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                IsScanning = true;
+                _ScanSessionTask = RunScanSessionAsync(_ScanSessionCts.Token);
+            }
+
+            return Task.FromResult(WifiManagerResponse<bool>.SuccessResponse(true, "Wi-Fi scan session started."));
+        }
+
+        public async Task<WifiManagerResponse<bool>> StopScanningAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            CancellationTokenSource? cts;
+            Task? scanTask;
+
+            lock (_ScanLock)
+            {
+                if (!IsScanning)
+                {
+                    return WifiManagerResponse<bool>.SuccessResponse(false, "No active scan session.");
+                }
+
+                cts = _ScanSessionCts;
+                scanTask = _ScanSessionTask;
+                IsScanning = false;
+                _ScanSessionCts = null;
+                _ScanSessionTask = null;
+            }
+
+            try
+            {
+                cts?.Cancel();
+                if (scanTask != null)
+                {
+                    await scanTask;
+                }
+            }
+            catch (System.OperationCanceledException)
+            {
+            }
+            finally
+            {
+                cts?.Dispose();
+            }
+
+            return WifiManagerResponse<bool>.SuccessResponse(true, "Wi-Fi scan session stopped.");
         }
 
         private async Task<WifiManagerResponse<NetworkData>> AddWifiSuggestion(WifiManager wifiManager, string ssid, string psk, string? bssid = null, CancellationToken cancellationToken = default)
@@ -830,7 +912,64 @@ namespace MauiWifiManager
         /// </summary>
         public void Dispose()
         {
+            _ = StopScanningAsync();
             StopMonitoring();
+        }
+
+        private async Task RunScanSessionAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var scanResponse = ScanWifiNetworksInternal(cancellationToken);
+                    if (scanResponse.ErrorCode == WifiErrorCodes.Success && scanResponse.Data != null)
+                    {
+                        foreach (var network in scanResponse.Data)
+                        {
+                            var key = BuildNetworkKey(network);
+                            if (string.IsNullOrWhiteSpace(key))
+                            {
+                                continue;
+                            }
+
+                            if (_DiscoveredNetworkKeys.Add(key))
+                            {
+                                _DeviceDiscovered?.Invoke(this, CloneNetworkData(network)!);
+                            }
+                        }
+                    }
+
+                    await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+                }
+            }
+            catch (System.OperationCanceledException)
+            {
+            }
+            finally
+            {
+                lock (_ScanLock)
+                {
+                    IsScanning = false;
+                    _ScanSessionCts?.Dispose();
+                    _ScanSessionCts = null;
+                    _ScanSessionTask = null;
+                    _DiscoveredNetworkKeys.Clear();
+                }
+            }
+        }
+
+        private static string BuildNetworkKey(NetworkData network)
+        {
+            var ssid = network.Ssid?.Trim() ?? string.Empty;
+            var bssid = network.Bssid?.ToString()?.Trim() ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(ssid) && string.IsNullOrWhiteSpace(bssid))
+            {
+                return string.Empty;
+            }
+
+            return string.Concat(ssid, "|", bssid);
         }
 
         private static int GetIpAddressFromBytes(byte[] address)
@@ -864,16 +1003,16 @@ namespace MauiWifiManager
 
         private void EnsureMonitoringStarted()
         {
-            lock (_monitorLock)
+            lock (_MonitorLock)
             {
-                if (_isMonitoring)
+                if (_IsMonitoring)
                 {
                     return;
                 }
 
                 NetworkChange.NetworkAddressChanged += OnNetworkChanged;
                 NetworkChange.NetworkAvailabilityChanged += OnNetworkAvailabilityChanged;
-                _isMonitoring = true;
+                _IsMonitoring = true;
             }
 
             _ = RefreshSnapshotAsync(raiseEvent: false);
@@ -881,17 +1020,17 @@ namespace MauiWifiManager
 
         private void StopMonitoring()
         {
-            lock (_monitorLock)
+            lock (_MonitorLock)
             {
-                if (!_isMonitoring)
+                if (!_IsMonitoring)
                 {
                     return;
                 }
 
                 NetworkChange.NetworkAddressChanged -= OnNetworkChanged;
                 NetworkChange.NetworkAvailabilityChanged -= OnNetworkAvailabilityChanged;
-                _isMonitoring = false;
-                _lastKnownNetwork = null;
+                _IsMonitoring = false;
+                _LastKnownNetwork = null;
             }
         }
 
@@ -925,16 +1064,16 @@ namespace MauiWifiManager
             NetworkData? oldNetwork;
             bool changed;
 
-            lock (_monitorLock)
+            lock (_MonitorLock)
             {
-                oldNetwork = CloneNetworkData(_lastKnownNetwork);
-                changed = !AreSameNetwork(_lastKnownNetwork, currentNetwork);
-                _lastKnownNetwork = CloneNetworkData(currentNetwork);
+                oldNetwork = CloneNetworkData(_LastKnownNetwork);
+                changed = !AreSameNetwork(_LastKnownNetwork, currentNetwork);
+                _LastKnownNetwork = CloneNetworkData(currentNetwork);
             }
 
             if (raiseEvent && changed)
             {
-                _wifiNetworkChanged?.Invoke(this, new WifiNetworkChangedEventArgs(oldNetwork, CloneNetworkData(currentNetwork)));
+                _WifiNetworkChanged?.Invoke(this, new WifiNetworkChangedEventArgs(oldNetwork, CloneNetworkData(currentNetwork)));
             }
         }
 

--- a/src/MAUIWifiManager/WifiNetworkService.apple.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.apple.cs
@@ -17,19 +17,22 @@ namespace MauiWifiManager
     public class WifiNetworkService : IWifiNetworkService
     {
         public NEHotspotHelper _HotspotHelper;
-        private EventHandler<WifiNetworkChangedEventArgs>? _wifiNetworkChanged;
-        private readonly object _monitorLock = new();
-        private NetworkData? _lastKnownNetwork;
-        private bool _isMonitoring;
+        private EventHandler<WifiNetworkChangedEventArgs>? _WifiNetworkChanged;
+        public event EventHandler<NetworkData>? DeviceDiscovered;
+        private readonly object _MonitorLock = new();
+        private NetworkData? _LastKnownNetwork;
+        private bool _IsMonitoring;
+
+        public bool IsScanning => false;
 
         public event EventHandler<WifiNetworkChangedEventArgs>? WifiNetworkChanged
         {
             add
             {
-                _wifiNetworkChanged += value;
+                _WifiNetworkChanged += value;
                 EnsureMonitoringStarted();
             }
-            remove => _wifiNetworkChanged -= value;
+            remove => _WifiNetworkChanged -= value;
         }
 
         public WifiNetworkService()
@@ -316,6 +319,26 @@ namespace MauiWifiManager
             return Task.FromResult(response);
         }
 
+        public Task<WifiManagerResponse<bool>> StartScanningForDevicesAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<WifiManagerResponse<bool>>(cancellationToken);
+            }
+
+            return Task.FromResult(WifiManagerResponse<bool>.ErrorResponse(WifiErrorCodes.WifiNotEnabled, "Continuous scanning is not supported on iOS."));
+        }
+
+        public Task<WifiManagerResponse<bool>> StopScanningAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<WifiManagerResponse<bool>>(cancellationToken);
+            }
+
+            return Task.FromResult(WifiManagerResponse<bool>.SuccessResponse(false, "No active scan session."));
+        }
+
         public async Task<bool> OpenWirelessSetting()
         {
             return await OpenSettings();
@@ -376,16 +399,16 @@ namespace MauiWifiManager
 
         private void EnsureMonitoringStarted()
         {
-            lock (_monitorLock)
+            lock (_MonitorLock)
             {
-                if (_isMonitoring)
+                if (_IsMonitoring)
                 {
                     return;
                 }
 
                 NetworkChange.NetworkAddressChanged += OnNetworkChanged;
                 NetworkChange.NetworkAvailabilityChanged += OnNetworkAvailabilityChanged;
-                _isMonitoring = true;
+                _IsMonitoring = true;
             }
 
             _ = RefreshSnapshotAsync(raiseEvent: false);
@@ -393,17 +416,17 @@ namespace MauiWifiManager
 
         private void StopMonitoring()
         {
-            lock (_monitorLock)
+            lock (_MonitorLock)
             {
-                if (!_isMonitoring)
+                if (!_IsMonitoring)
                 {
                     return;
                 }
 
                 NetworkChange.NetworkAddressChanged -= OnNetworkChanged;
                 NetworkChange.NetworkAvailabilityChanged -= OnNetworkAvailabilityChanged;
-                _isMonitoring = false;
-                _lastKnownNetwork = null;
+                _IsMonitoring = false;
+                _LastKnownNetwork = null;
             }
         }
 
@@ -437,16 +460,16 @@ namespace MauiWifiManager
             NetworkData? oldNetwork;
             bool changed;
 
-            lock (_monitorLock)
+            lock (_MonitorLock)
             {
-                oldNetwork = CloneNetworkData(_lastKnownNetwork);
-                changed = !AreSameNetwork(_lastKnownNetwork, currentNetwork);
-                _lastKnownNetwork = CloneNetworkData(currentNetwork);
+                oldNetwork = CloneNetworkData(_LastKnownNetwork);
+                changed = !AreSameNetwork(_LastKnownNetwork, currentNetwork);
+                _LastKnownNetwork = CloneNetworkData(currentNetwork);
             }
 
             if (raiseEvent && changed)
             {
-                _wifiNetworkChanged?.Invoke(this, new WifiNetworkChangedEventArgs(oldNetwork, CloneNetworkData(currentNetwork)));
+                _WifiNetworkChanged?.Invoke(this, new WifiNetworkChangedEventArgs(oldNetwork, CloneNetworkData(currentNetwork)));
             }
         }
 

--- a/src/MAUIWifiManager/WifiNetworkService.net.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.net.cs
@@ -10,6 +10,9 @@ namespace MauiWifiManager
     public class WifiNetworkService : IWifiNetworkService
     {
         public event EventHandler<WifiNetworkChangedEventArgs>? WifiNetworkChanged;
+        public event EventHandler<NetworkData>? DeviceDiscovered;
+
+        public bool IsScanning => false;
 
         public WifiNetworkService() { }
 
@@ -71,6 +74,26 @@ namespace MauiWifiManager
                 return Task.FromCanceled<WifiManagerResponse<List<NetworkData>>>(cancellationToken);
             }
             return Task.FromResult(WifiManagerResponse<List<NetworkData>>.ErrorResponse(WifiErrorCodes.NetworkUnavailable, "Platform Wi-Fi implementation is not available in this build."));
+        }
+
+        public Task<WifiManagerResponse<bool>> StartScanningForDevicesAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<WifiManagerResponse<bool>>(cancellationToken);
+            }
+
+            return Task.FromResult(WifiManagerResponse<bool>.ErrorResponse(WifiErrorCodes.NetworkUnavailable, "Platform Wi-Fi implementation is not available in this build."));
+        }
+
+        public Task<WifiManagerResponse<bool>> StopScanningAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<WifiManagerResponse<bool>>(cancellationToken);
+            }
+
+            return Task.FromResult(WifiManagerResponse<bool>.SuccessResponse(false, "No active scan session."));
         }
 
         public Task<bool> OpenWirelessSetting()

--- a/src/MAUIWifiManager/WifiNetworkService.windows.cs
+++ b/src/MAUIWifiManager/WifiNetworkService.windows.cs
@@ -13,19 +13,32 @@ namespace MauiWifiManager
     /// </summary>
     public class WifiNetworkService : IWifiNetworkService
     {
-        private EventHandler<WifiNetworkChangedEventArgs>? _wifiNetworkChanged;
-        private readonly object _monitorLock = new();
-        private NetworkData? _lastKnownNetwork;
-        private bool _isMonitoring;
+        private EventHandler<WifiNetworkChangedEventArgs>? _WifiNetworkChanged;
+        private EventHandler<NetworkData>? _DeviceDiscovered;
+        private readonly object _MonitorLock = new();
+        private readonly object _ScanLock = new();
+        private NetworkData? _LastKnownNetwork;
+        private CancellationTokenSource? _ScanSessionCts;
+        private Task? _ScanSessionTask;
+        private readonly HashSet<string> _DiscoveredNetworkKeys = new(StringComparer.OrdinalIgnoreCase);
+        private bool _IsMonitoring;
+
+        public bool IsScanning { get; private set; }
 
         public event EventHandler<WifiNetworkChangedEventArgs>? WifiNetworkChanged
         {
             add
             {
-                _wifiNetworkChanged += value;
+                _WifiNetworkChanged += value;
                 EnsureMonitoringStarted();
             }
-            remove => _wifiNetworkChanged -= value;
+            remove => _WifiNetworkChanged -= value;
+        }
+
+        public event EventHandler<NetworkData>? DeviceDiscovered
+        {
+            add => _DeviceDiscovered += value;
+            remove => _DeviceDiscovered -= value;
         }
 
         public WifiNetworkService()
@@ -254,6 +267,7 @@ namespace MauiWifiManager
         /// </summary>
         public void Dispose()
         {
+            _ = StopScanningAsync();
             StopMonitoring();
         }
 
@@ -319,6 +333,69 @@ namespace MauiWifiManager
             return response;
         }
 
+        public Task<WifiManagerResponse<bool>> StartScanningForDevicesAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromResult(WifiManagerResponse<bool>.ErrorResponse(WifiErrorCodes.OperationCanceled, "StartScanningForDevicesAsync operation was canceled."));
+            }
+
+            lock (_ScanLock)
+            {
+                if (IsScanning)
+                {
+                    return Task.FromResult(WifiManagerResponse<bool>.SuccessResponse(true, "Scan session is already running."));
+                }
+
+                _DiscoveredNetworkKeys.Clear();
+                _ScanSessionCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                IsScanning = true;
+                _ScanSessionTask = RunScanSessionAsync(_ScanSessionCts.Token);
+            }
+
+            return Task.FromResult(WifiManagerResponse<bool>.SuccessResponse(true, "Wi-Fi scan session started."));
+        }
+
+        public async Task<WifiManagerResponse<bool>> StopScanningAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            CancellationTokenSource? cts;
+            Task? scanTask;
+
+            lock (_ScanLock)
+            {
+                if (!IsScanning)
+                {
+                    return WifiManagerResponse<bool>.SuccessResponse(false, "No active scan session.");
+                }
+
+                cts = _ScanSessionCts;
+                scanTask = _ScanSessionTask;
+                IsScanning = false;
+                _ScanSessionCts = null;
+                _ScanSessionTask = null;
+            }
+
+            try
+            {
+                cts?.Cancel();
+                if (scanTask != null)
+                {
+                    await scanTask;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                cts?.Dispose();
+            }
+
+            return WifiManagerResponse<bool>.SuccessResponse(true, "Wi-Fi scan session stopped.");
+        }
+
 
         /// <summary>
         /// Open Network and Internet Setting
@@ -330,16 +407,16 @@ namespace MauiWifiManager
 
         private void EnsureMonitoringStarted()
         {
-            lock (_monitorLock)
+            lock (_MonitorLock)
             {
-                if (_isMonitoring)
+                if (_IsMonitoring)
                 {
                     return;
                 }
 
                 NetworkChange.NetworkAddressChanged += OnNetworkChanged;
                 NetworkChange.NetworkAvailabilityChanged += OnNetworkAvailabilityChanged;
-                _isMonitoring = true;
+                _IsMonitoring = true;
             }
 
             _ = RefreshSnapshotAsync(raiseEvent: false);
@@ -347,17 +424,17 @@ namespace MauiWifiManager
 
         private void StopMonitoring()
         {
-            lock (_monitorLock)
+            lock (_MonitorLock)
             {
-                if (!_isMonitoring)
+                if (!_IsMonitoring)
                 {
                     return;
                 }
 
                 NetworkChange.NetworkAddressChanged -= OnNetworkChanged;
                 NetworkChange.NetworkAvailabilityChanged -= OnNetworkAvailabilityChanged;
-                _isMonitoring = false;
-                _lastKnownNetwork = null;
+                _IsMonitoring = false;
+                _LastKnownNetwork = null;
             }
         }
 
@@ -391,16 +468,16 @@ namespace MauiWifiManager
             NetworkData? oldNetwork;
             bool changed;
 
-            lock (_monitorLock)
+            lock (_MonitorLock)
             {
-                oldNetwork = CloneNetworkData(_lastKnownNetwork);
-                changed = !AreSameNetwork(_lastKnownNetwork, currentNetwork);
-                _lastKnownNetwork = CloneNetworkData(currentNetwork);
+                oldNetwork = CloneNetworkData(_LastKnownNetwork);
+                changed = !AreSameNetwork(_LastKnownNetwork, currentNetwork);
+                _LastKnownNetwork = CloneNetworkData(currentNetwork);
             }
 
             if (raiseEvent && changed)
             {
-                _wifiNetworkChanged?.Invoke(this, new WifiNetworkChangedEventArgs(oldNetwork, CloneNetworkData(currentNetwork)));
+                _WifiNetworkChanged?.Invoke(this, new WifiNetworkChangedEventArgs(oldNetwork, CloneNetworkData(currentNetwork)));
             }
         }
 
@@ -440,6 +517,62 @@ namespace MauiWifiManager
                 SignalStrength = source.SignalStrength,
                 SecurityType = source.SecurityType
             };
+        }
+
+        private async Task RunScanSessionAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var scanResponse = await ScanWifiNetworksAsync(cancellationToken);
+                    if (scanResponse.ErrorCode == WifiErrorCodes.Success && scanResponse.Data != null)
+                    {
+                        foreach (var network in scanResponse.Data)
+                        {
+                            var key = BuildNetworkKey(network);
+                            if (string.IsNullOrWhiteSpace(key))
+                            {
+                                continue;
+                            }
+
+                            if (_DiscoveredNetworkKeys.Add(key))
+                            {
+                                _DeviceDiscovered?.Invoke(this, CloneNetworkData(network)!);
+                            }
+                        }
+                    }
+
+                    await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                lock (_ScanLock)
+                {
+                    IsScanning = false;
+                    _ScanSessionCts?.Dispose();
+                    _ScanSessionCts = null;
+                    _ScanSessionTask = null;
+                    _DiscoveredNetworkKeys.Clear();
+                }
+            }
+        }
+
+        private static string BuildNetworkKey(NetworkData network)
+        {
+            var ssid = network.Ssid?.Trim() ?? string.Empty;
+            var bssid = network.Bssid?.ToString()?.Trim() ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(ssid) && string.IsNullOrWhiteSpace(bssid))
+            {
+                return string.Empty;
+            }
+
+            return string.Concat(ssid, "|", bssid);
         }
 
         private string GetSecurityType(NetworkAuthenticationType authType)


### PR DESCRIPTION
Discover nearby Wi-Fi networks as they are found, with live updates through discovery events and full scan session control using start, stop, and scanning state APIs.